### PR TITLE
Compiler bug was fixed in VC++ 2013, workaround no longer necessary.

### DIFF
--- a/include/boost/proto/expr.hpp
+++ b/include/boost/proto/expr.hpp
@@ -92,7 +92,7 @@ namespace boost { namespace proto
 
         // Work-around for:
         // https://connect.microsoft.com/VisualStudio/feedback/details/765449/codegen-stack-corruption-using-runtime-checks-when-aggregate-initializing-struct
-    #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1700))
+    #if BOOST_WORKAROUND(BOOST_MSVC, < 1800)
         template<typename T, typename Expr, typename C, typename U>
         BOOST_FORCEINLINE
         Expr make_terminal(T &t, Expr *, proto::term<U C::*> *)

--- a/include/boost/proto/generate.hpp
+++ b/include/boost/proto/generate.hpp
@@ -230,7 +230,7 @@ namespace boost { namespace proto
 
         // Work-around for:
         // https://connect.microsoft.com/VisualStudio/feedback/details/765449/codegen-stack-corruption-using-runtime-checks-when-aggregate-initializing-struct
-    #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1700))
+    #if BOOST_WORKAROUND(BOOST_MSVC, < 1800)
         template<typename Class, typename Member>
         BOOST_FORCEINLINE
         Extends<expr<tag::terminal, proto::term<Member Class::*> > > operator ()(expr<tag::terminal, proto::term<Member Class::*> > const &e) const


### PR DESCRIPTION
This bug was fixed in VC++ 2013, the workaround is no longer necessary. I noticed the fix as of VC++ 2013 Update 2, so I don't know if the fix was in RTM or in an update, so it may be more prudent to set the value to `1900` instead...
