### PR TITLE
Wrap the display_expr_impl with boost::ref and pass it to fusion::for…

### DIFF
--- a/include/boost/proto/debug.hpp
+++ b/include/boost/proto/debug.hpp
@@ -11,6 +11,7 @@
 
 #include <iostream>
 #include <boost/preprocessor/stringize.hpp>
+#include <boost/bind.hpp>
 #include <boost/ref.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/proto/proto_fwd.hpp>
@@ -152,7 +153,7 @@ namespace boost { namespace proto
                 this->sout_ << (this->first_? "" : ", ");
                 this->sout_ << tag() << "(\n";
                 display_expr_impl display(this->sout_, this->depth_ + 4);
-                fusion::for_each(expr, display);
+                fusion::for_each(expr, boost::bind<void>(boost::ref(display), _1));
                 this->sout_.width(this->depth_);
                 this->sout_ << "" << ")\n";
                 this->first_ = false;


### PR DESCRIPTION
…_each

Previously, boost::fusion::for_each was accepting const reference
as a functor, but it was changed in 1.68 to accept a value type instead
(https://github.com/boostorg/fusion/commit/102588ae4636ffb418ee678d5d71d110bfcd0eb4).

This adapts proto to pass the functor as a value using
boost::bind/boost::ref instead passing a non-copyable functor which
would generate copy constructor call.