### PR TITLE
Suppress C4180 warning from extends operators

### DIFF
--- a/include/boost/proto/extends.hpp
+++ b/include/boost/proto/extends.hpp
@@ -74,6 +74,7 @@ namespace boost { namespace proto
     ///
     #define BOOST_PROTO_DEFINE_FUN_OP_IMPL_(Z, N, DATA, Const)                                      \
         BOOST_PP_IF(N, BOOST_PROTO_TEMPLATE_YES_, BOOST_PROTO_TEMPLATE_NO_)(Z, N)                   \
+        BOOST_PROTO_DISABLE_MSVC_C4180                                                              \
         BOOST_PROTO_DISABLE_MSVC_C4714 BOOST_FORCEINLINE                                            \
         typename BOOST_PROTO_RESULT_OF<                                                             \
             proto_generator(                                                                        \
@@ -104,6 +105,7 @@ namespace boost { namespace proto
     ///
     #define BOOST_PROTO_DEFINE_FUN_OP_VARIADIC_IMPL_(Const)                                         \
         template<typename... A>                                                                     \
+        BOOST_PROTO_DISABLE_MSVC_C4180                                                              \
         BOOST_PROTO_DISABLE_MSVC_C4714 BOOST_FORCEINLINE                                            \
         typename BOOST_PROTO_RESULT_OF<                                                             \
             proto_generator(                                                                        \
@@ -258,6 +260,7 @@ namespace boost { namespace proto
         ///
     #define BOOST_PROTO_EXTENDS_ASSIGN_IMPL_(ThisConst, ThatConst)                                  \
         template<typename A>                                                                        \
+        BOOST_PROTO_DISABLE_MSVC_C4180                                                              \
         BOOST_PROTO_DISABLE_MSVC_C4714 BOOST_FORCEINLINE                                            \
         typename BOOST_PROTO_RESULT_OF<                                                             \
             proto_generator(                                                                        \
@@ -325,6 +328,7 @@ namespace boost { namespace proto
         ///
     #define BOOST_PROTO_EXTENDS_SUBSCRIPT_IMPL_(ThisConst, ThatConst)                               \
         template<typename A>                                                                        \
+        BOOST_PROTO_DISABLE_MSVC_C4180                                                              \
         BOOST_PROTO_DISABLE_MSVC_C4714 BOOST_FORCEINLINE                                            \
         typename BOOST_PROTO_RESULT_OF<                                                             \
             proto_generator(                                                                        \

--- a/include/boost/proto/proto_fwd.hpp
+++ b/include/boost/proto/proto_fwd.hpp
@@ -124,9 +124,11 @@
 #endif
 
 #if defined(_MSC_VER)
+# define BOOST_PROTO_DISABLE_MSVC_C4180 __pragma(warning(disable : 4180))  // qualifier applied to function type has no meaning; ignored
 # define BOOST_PROTO_DISABLE_MSVC_C4522 __pragma(warning(disable : 4522))  // 'class' : multiple assignment operators specified
 # define BOOST_PROTO_DISABLE_MSVC_C4714 __pragma(warning(disable : 4714))  // function 'xxx' marked as __forceinline not inlined
 #else
+# define BOOST_PROTO_DISABLE_MSVC_C4180
 # define BOOST_PROTO_DISABLE_MSVC_C4522 
 # define BOOST_PROTO_DISABLE_MSVC_C4714
 #endif


### PR DESCRIPTION
The warning is harmless and can be safely suppressed.

Fixes an half of #12 that affects Spirit.
