### PR TITLE
Fix `examples` test

### DIFF
--- a/test/examples.cpp
+++ b/test/examples.cpp
@@ -127,8 +127,8 @@ struct binary_arity
 };
 //]
 
-proto::terminal< placeholder<0> >::type const _1 = {{}};
-proto::terminal< placeholder<1> >::type const _2 = {{}};
+proto::terminal< placeholder<0> >::type const _1 = {};
+proto::terminal< placeholder<1> >::type const _2 = {};
 
 //[ CalculatorArityGrammar
 struct CalculatorArity
@@ -355,11 +355,7 @@ namespace lambda_transform
 {
     //[LambdaTransform
     template<typename N>
-    struct placeholder
-    {
-        typedef typename N::type type;
-        static typename N::value_type const value = N::value;
-    };
+    struct placeholder : N {};
 
     // A function object that calls fusion::at()
     struct at : proto::callable
@@ -401,8 +397,8 @@ namespace lambda_transform
     {};
 
     // Define the lambda placeholders
-    proto::terminal<placeholder<mpl::int_<0> > >::type const _1 = {{}};
-    proto::terminal<placeholder<mpl::int_<1> > >::type const _2 = {{}};
+    proto::terminal<placeholder<mpl::int_<0> > >::type const _1 = {};
+    proto::terminal<placeholder<mpl::int_<1> > >::type const _2 = {};
 
     void test_lambda()
     {

--- a/test/examples.cpp
+++ b/test/examples.cpp
@@ -178,20 +178,18 @@ struct CalcArity
 struct ArgsAsList
   : proto::when<
         proto::function<proto::terminal<_>, proto::vararg<proto::terminal<_> > >
-      /*<< Use a `reverse_fold<>` transform to iterate over the children
-      of this node in reverse order, building a fusion list from back to
-      front. >>*/
-      , proto::reverse_fold<
+      /*<< Use a `fold<>` transform to iterate over the children of this
+      node in forward order, building a fusion list from front to back. >>*/
+      , proto::fold<
             /*<< The first child expression of a `function<>` node is the
             function being invoked. We don't want that in our list, so use
             `pop_front()` to remove it. >>*/
             proto::_pop_front(_)
-          /*<< `nil` is the initial state used by the `reverse_fold<>`
-          transform. >>*/
+          /*<< `nil` is the initial state used by the `fold<>` transform. >>*/
           , fusion::nil()
           /*<< Put the rest of the function arguments in a fusion cons
           list. >>*/
-          , fusion::cons<proto::_value, proto::_state>(proto::_value, proto::_state)
+          , proto::functional::push_back(proto::_state, proto::_value)
         >
     >
 {};


### PR DESCRIPTION
It has two issues, one regarding MPL, and other about breaking Fusion invariant.

Tested on MSVC 9/10/11/14.0/14.1, Clang 7, GCC 8.

Fixes #5