### PR TITLE
Missing diagnostic push/pop

### DIFF
--- a/include/boost/proto/extends.hpp
+++ b/include/boost/proto/extends.hpp
@@ -74,6 +74,7 @@ namespace boost { namespace proto
     ///
     #define BOOST_PROTO_DEFINE_FUN_OP_IMPL_(Z, N, DATA, Const)                                      \
         BOOST_PP_IF(N, BOOST_PROTO_TEMPLATE_YES_, BOOST_PROTO_TEMPLATE_NO_)(Z, N)                   \
+        BOOST_PROTO_PUSH_WARNINGS                                                                   \
         BOOST_PROTO_DISABLE_MSVC_C4180                                                              \
         BOOST_PROTO_DISABLE_MSVC_C4714 BOOST_FORCEINLINE                                            \
         typename BOOST_PROTO_RESULT_OF<                                                             \
@@ -99,12 +100,14 @@ namespace boost { namespace proto
                 )                                                                                   \
             );                                                                                      \
         }                                                                                           \
+        BOOST_PROTO_POP_WARNINGS                                                                    \
         /**/
 
     /// INTERNAL ONLY
     ///
     #define BOOST_PROTO_DEFINE_FUN_OP_VARIADIC_IMPL_(Const)                                         \
         template<typename... A>                                                                     \
+        BOOST_PROTO_PUSH_WARNINGS                                                                   \
         BOOST_PROTO_DISABLE_MSVC_C4180                                                              \
         BOOST_PROTO_DISABLE_MSVC_C4714 BOOST_FORCEINLINE                                            \
         typename BOOST_PROTO_RESULT_OF<                                                             \
@@ -130,6 +133,7 @@ namespace boost { namespace proto
                 )                                                                                   \
             );                                                                                      \
         }                                                                                           \
+        BOOST_PROTO_POP_WARNINGS                                                                    \
         /**/
 
     /// INTERNAL ONLY
@@ -177,6 +181,8 @@ namespace boost { namespace proto
         typedef boost::proto::tag::proto_expr<proto_tag, proto_domain> fusion_tag;                  \
         BOOST_PP_REPEAT(BOOST_PROTO_MAX_ARITY, BOOST_PROTO_EXTENDS_CHILD, ~)                        \
                                                                                                     \
+        BOOST_PROTO_PUSH_WARNINGS                                                                   \
+                                                                                                    \
         BOOST_PROTO_DISABLE_MSVC_C4714 BOOST_FORCEINLINE                                            \
         static proto_derived_expr const make(Expr const &e)                                         \
         {                                                                                           \
@@ -201,6 +207,8 @@ namespace boost { namespace proto
         {                                                                                           \
             return boost::addressof(this->proto_base().child0);                                     \
         }                                                                                           \
+                                                                                                    \
+        BOOST_PROTO_POP_WARNINGS                                                                    \
         /**/
 
     #define BOOST_PROTO_BASIC_EXTENDS(Expr, Derived, Domain)                                        \
@@ -209,6 +217,7 @@ namespace boost { namespace proto
         /**< INTERNAL ONLY */
 
     #define BOOST_PROTO_EXTENDS_COPY_ASSIGN_IMPL_(This, Const, Typename)                            \
+        BOOST_PROTO_PUSH_WARNINGS                                                                   \
         BOOST_PROTO_DISABLE_MSVC_C4522                                                              \
         BOOST_PROTO_DISABLE_MSVC_C4714 BOOST_FORCEINLINE                                            \
         Typename() BOOST_PROTO_RESULT_OF<                                                           \
@@ -241,6 +250,7 @@ namespace boost { namespace proto
             };                                                                                      \
             return Typename() This::proto_generator()(that);                                        \
         }                                                                                           \
+        BOOST_PROTO_POP_WARNINGS                                                                    \
         /**/
 
         // MSVC 8.0 and higher seem to need copy-assignment operator to be overloaded on *both*
@@ -260,6 +270,7 @@ namespace boost { namespace proto
         ///
     #define BOOST_PROTO_EXTENDS_ASSIGN_IMPL_(ThisConst, ThatConst)                                  \
         template<typename A>                                                                        \
+        BOOST_PROTO_PUSH_WARNINGS                                                                   \
         BOOST_PROTO_DISABLE_MSVC_C4180                                                              \
         BOOST_PROTO_DISABLE_MSVC_C4714 BOOST_FORCEINLINE                                            \
         typename BOOST_PROTO_RESULT_OF<                                                             \
@@ -292,6 +303,7 @@ namespace boost { namespace proto
             };                                                                                      \
             return proto_generator()(that);                                                         \
         }                                                                                           \
+        BOOST_PROTO_POP_WARNINGS                                                                    \
         /**/
 
     #define BOOST_PROTO_EXTENDS_ASSIGN_CONST_()                                                     \
@@ -328,6 +340,7 @@ namespace boost { namespace proto
         ///
     #define BOOST_PROTO_EXTENDS_SUBSCRIPT_IMPL_(ThisConst, ThatConst)                               \
         template<typename A>                                                                        \
+        BOOST_PROTO_PUSH_WARNINGS                                                                   \
         BOOST_PROTO_DISABLE_MSVC_C4180                                                              \
         BOOST_PROTO_DISABLE_MSVC_C4714 BOOST_FORCEINLINE                                            \
         typename BOOST_PROTO_RESULT_OF<                                                             \
@@ -360,6 +373,7 @@ namespace boost { namespace proto
             };                                                                                      \
             return proto_generator()(that);                                                         \
         }                                                                                           \
+        BOOST_PROTO_POP_WARNINGS                                                                    \
         /**/
 
     #define BOOST_PROTO_EXTENDS_SUBSCRIPT_CONST()                                                   \

--- a/include/boost/proto/operators.hpp
+++ b/include/boost/proto/operators.hpp
@@ -104,6 +104,8 @@ namespace boost { namespace proto
 #ifdef BOOST_NO_CXX11_RVALUE_REFERENCES
 
 #define BOOST_PROTO_DEFINE_UNARY_OPERATOR(OP, TAG, TRAIT, DOMAIN, POST)                             \
+    BOOST_PROTO_PUSH_WARNINGS                                                                       \
+                                                                                                    \
     template<typename Arg>                                                                          \
     BOOST_PROTO_DISABLE_MSVC_C4714 BOOST_FORCEINLINE                                                \
     typename boost::proto::detail::enable_unary<                                                    \
@@ -131,9 +133,13 @@ namespace boost { namespace proto
     {                                                                                               \
         return boost::proto::detail::make_expr_<TAG, DOMAIN, Arg const &>()(arg);                   \
     }                                                                                               \
+                                                                                                    \
+    BOOST_PROTO_POP_WARNINGS                                                                        \
     /**/
 
 #define BOOST_PROTO_DEFINE_BINARY_OPERATOR(OP, TAG, TRAIT, DOMAIN)                                  \
+    BOOST_PROTO_PUSH_WARNINGS                                                                       \
+                                                                                                    \
     template<typename Left, typename Right>                                                         \
     BOOST_PROTO_DISABLE_MSVC_C4714 BOOST_FORCEINLINE                                                \
     typename boost::proto::detail::enable_binary<                                                   \
@@ -193,12 +199,15 @@ namespace boost { namespace proto
     {                                                                                               \
         return boost::proto::detail::make_expr_<TAG, DOMAIN, Left const &, Right const &>()(left, right);\
     }                                                                                               \
+                                                                                                    \
+    BOOST_PROTO_POP_WARNINGS                                                                        \
     /**/
 
 #else
 
 #define BOOST_PROTO_DEFINE_UNARY_OPERATOR(OP, TAG, TRAIT, DOMAIN, POST)                             \
     template<typename Arg>                                                                          \
+    BOOST_PROTO_PUSH_WARNINGS                                                                       \
     BOOST_PROTO_DISABLE_MSVC_C4714 BOOST_FORCEINLINE                                                \
     typename boost::proto::detail::enable_unary<                                                    \
         DOMAIN                                                                                      \
@@ -211,10 +220,12 @@ namespace boost { namespace proto
     {                                                                                               \
         return boost::proto::detail::make_expr_<TAG, DOMAIN, Arg const &>()(arg);                   \
     }                                                                                               \
+    BOOST_PROTO_POP_WARNINGS                                                                        \
     /**/
 
 #define BOOST_PROTO_DEFINE_BINARY_OPERATOR(OP, TAG, TRAIT, DOMAIN)                                  \
     template<typename Left, typename Right>                                                         \
+    BOOST_PROTO_PUSH_WARNINGS                                                                       \
     BOOST_PROTO_DISABLE_MSVC_C4714 BOOST_FORCEINLINE                                                \
     typename boost::proto::detail::enable_binary<                                                   \
         DOMAIN                                                                                      \
@@ -228,6 +239,7 @@ namespace boost { namespace proto
     {                                                                                               \
         return boost::proto::detail::make_expr_<TAG, DOMAIN, Left const &, Right const &>()(left, right);\
     }                                                                                               \
+    BOOST_PROTO_POP_WARNINGS                                                                        \
     /**/
 
 #endif

--- a/include/boost/proto/proto_fwd.hpp
+++ b/include/boost/proto/proto_fwd.hpp
@@ -124,10 +124,14 @@
 #endif
 
 #if defined(_MSC_VER)
+# define BOOST_PROTO_PUSH_WARNINGS __pragma(warning(push))
+# define BOOST_PROTO_POP_WARNINGS __pragma(warning(pop))
 # define BOOST_PROTO_DISABLE_MSVC_C4180 __pragma(warning(disable : 4180))  // qualifier applied to function type has no meaning; ignored
 # define BOOST_PROTO_DISABLE_MSVC_C4522 __pragma(warning(disable : 4522))  // 'class' : multiple assignment operators specified
 # define BOOST_PROTO_DISABLE_MSVC_C4714 __pragma(warning(disable : 4714))  // function 'xxx' marked as __forceinline not inlined
 #else
+# define BOOST_PROTO_PUSH_WARNINGS
+# define BOOST_PROTO_POP_WARNINGS
 # define BOOST_PROTO_DISABLE_MSVC_C4180
 # define BOOST_PROTO_DISABLE_MSVC_C4522 
 # define BOOST_PROTO_DISABLE_MSVC_C4714


### PR DESCRIPTION
The used pragmas were not just disabling warnings for a particular function