### PR TITLE
Fix -Wdeprecated-copy (Clang, but partly GCC)

### DIFF
--- a/include/boost/proto/context/callable.hpp
+++ b/include/boost/proto/context/callable.hpp
@@ -42,8 +42,8 @@ namespace boost { namespace proto
             callable_context_wrapper();
             typedef private_type_ fun_type(...);
             operator fun_type *() const;
-        private:
-            callable_context_wrapper &operator =(callable_context_wrapper const &);
+
+            BOOST_DELETED_FUNCTION(callable_context_wrapper &operator =(callable_context_wrapper const &))
         };
 
         template<typename T>

--- a/include/boost/proto/debug.hpp
+++ b/include/boost/proto/debug.hpp
@@ -92,8 +92,7 @@ namespace boost { namespace proto
 
             std::ostream &sout_;
 
-        private:
-            ostream_wrapper &operator =(ostream_wrapper const &);
+            BOOST_DELETED_FUNCTION(ostream_wrapper &operator =(ostream_wrapper const &))
         };
 
         struct named_any
@@ -145,9 +144,9 @@ namespace boost { namespace proto
                 this->impl(expr, mpl::long_<arity_of<Expr>::value>());
             }
 
+            BOOST_DELETED_FUNCTION(display_expr_impl(display_expr_impl const &))
+            BOOST_DELETED_FUNCTION(display_expr_impl &operator =(display_expr_impl const &))
         private:
-            display_expr_impl(display_expr_impl const &);
-            display_expr_impl &operator =(display_expr_impl const &);
 
             template<typename Expr>
             void impl(Expr const &expr, mpl::long_<0>) const

--- a/include/boost/proto/detail/any.hpp
+++ b/include/boost/proto/detail/any.hpp
@@ -24,7 +24,6 @@ namespace boost { namespace proto
             struct any
             {
                 template<typename T> any(T const &) {}
-                any operator=(any);
                 any operator[](any);
                 #define M0(Z, N, DATA) any operator()(BOOST_PP_ENUM_PARAMS_Z(Z, N, any BOOST_PP_INTERCEPT));
                 BOOST_PP_REPEAT(BOOST_PROTO_MAX_ARITY, M0, ~)

--- a/include/boost/proto/detail/poly_function.hpp
+++ b/include/boost/proto/detail/poly_function.hpp
@@ -111,8 +111,8 @@ namespace boost { namespace proto { namespace detail
             return this->value;
         }
 
+        BOOST_DELETED_FUNCTION(arg &operator =(arg const &))
     private:
-        arg &operator =(arg const &);
         type value;
     };
 
@@ -135,8 +135,8 @@ namespace boost { namespace proto { namespace detail
             return this->value;
         }
 
+        BOOST_DELETED_FUNCTION(arg &operator =(arg const &))
     private:
-        arg &operator =(arg const &);
         type value;
     };
 

--- a/include/boost/proto/expr.hpp
+++ b/include/boost/proto/expr.hpp
@@ -132,9 +132,21 @@ namespace boost { namespace proto
         // actually defined:
         #include <boost/proto/detail/basic_expr.hpp>
 
+        #if defined(__GNUC__) && __GNUC__ >= 9 || defined(__clang__) && __clang_major__ >= 10
+            #pragma GCC diagnostic push
+            // The warning cannot be fixed for aggregates
+            // Sadly, GCC currently emits the warning at the use location:
+            // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94492
+            #pragma GCC diagnostic ignored "-Wdeprecated-copy"
+        #endif
+
         // This is where the expr specialization are
         // actually defined:
         #include <boost/proto/detail/expr.hpp>
+
+        #if defined(__GNUC__) && __GNUC__ >= 9 || defined(__clang__) && __clang_major__ >= 10
+            #pragma GCC diagnostic pop
+        #endif
     }
 
     /// \brief Lets you inherit the interface of an expression

--- a/include/boost/proto/literal.hpp
+++ b/include/boost/proto/literal.hpp
@@ -50,6 +50,10 @@ namespace boost { namespace proto
               : base_type(terminal_type::make(T()))
             {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            literal(literal const &) = default;
+#endif
+
             template<typename U>
             literal(U &u)
               : base_type(terminal_type::make(u))


### PR DESCRIPTION
Initially I was planning to suppress the warning inside `BOOST_PROTO_EXTENDS_COPY_ASSIGN_` macro too since there is no way to fix it for aggregate types, but it is probably an overkill, hopefully in Phoenix there is only one place where it is needed and in Spirit copy constructors are explicitly defined.

Fixes #22