### PR TITLE
Fix -Wdeprecated-copy follow-up

### DIFF
--- a/include/boost/proto/extends.hpp
+++ b/include/boost/proto/extends.hpp
@@ -524,11 +524,6 @@ namespace boost { namespace proto
             {}
 
             BOOST_FORCEINLINE
-            extends(extends const &that)
-              : proto_expr_(that.proto_expr_)
-            {}
-
-            BOOST_FORCEINLINE
             extends(Expr const &expr_)
               : proto_expr_(expr_)
             {}
@@ -552,11 +547,6 @@ namespace boost { namespace proto
             BOOST_FORCEINLINE
             extends()
               : proto_expr_()
-            {}
-
-            BOOST_FORCEINLINE
-            extends(extends const &that)
-              : proto_expr_(that.proto_expr_)
             {}
 
             BOOST_FORCEINLINE


### PR DESCRIPTION
This one did not show up in Proto tests, but in Spirit.