### PR TITLE
Fix -Wdeprecated-missing-comma-variadic-parameter (Clang)

### DIFF
--- a/include/boost/proto/transform/detail/preprocessed/call.hpp
+++ b/include/boost/proto/transform/detail/preprocessed/call.hpp
@@ -9,7 +9,7 @@
     
     
     template<typename Fun , typename A0>
-    struct call<Fun(A0...)> : transform<call<Fun(A0...)> >
+    struct call<Fun(A0, ...)> : transform<call<Fun(A0, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -29,7 +29,7 @@
     
     
     template<typename Fun , typename A0 , typename A1>
-    struct call<Fun(A0 , A1...)> : transform<call<Fun(A0 , A1...)> >
+    struct call<Fun(A0 , A1, ...)> : transform<call<Fun(A0 , A1, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -49,7 +49,7 @@
     
     
     template<typename Fun , typename A0 , typename A1 , typename A2>
-    struct call<Fun(A0 , A1 , A2...)> : transform<call<Fun(A0 , A1 , A2...)> >
+    struct call<Fun(A0 , A1 , A2, ...)> : transform<call<Fun(A0 , A1 , A2, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -100,7 +100,7 @@
     
     
     template<typename Fun , typename A0 , typename A1 , typename A2 , typename A3>
-    struct call<Fun(A0 , A1 , A2 , A3...)> : transform<call<Fun(A0 , A1 , A2 , A3...)> >
+    struct call<Fun(A0 , A1 , A2 , A3, ...)> : transform<call<Fun(A0 , A1 , A2 , A3, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -151,7 +151,7 @@
     
     
     template<typename Fun , typename A0 , typename A1 , typename A2 , typename A3 , typename A4>
-    struct call<Fun(A0 , A1 , A2 , A3 , A4...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4...)> >
+    struct call<Fun(A0 , A1 , A2 , A3 , A4, ...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -202,7 +202,7 @@
     
     
     template<typename Fun , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5>
-    struct call<Fun(A0 , A1 , A2 , A3 , A4 , A5...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , A5...)> >
+    struct call<Fun(A0 , A1 , A2 , A3 , A4 , A5, ...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , A5, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -253,7 +253,7 @@
     
     
     template<typename Fun , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6>
-    struct call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6...)> >
+    struct call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6, ...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -304,7 +304,7 @@
     
     
     template<typename Fun , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7>
-    struct call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7...)> >
+    struct call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7, ...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -355,7 +355,7 @@
     
     
     template<typename Fun , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7 , typename A8>
-    struct call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8...)> >
+    struct call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8, ...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -406,7 +406,7 @@
     
     
     template<typename Fun , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7 , typename A8 , typename A9>
-    struct call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9...)> >
+    struct call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9, ...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl

--- a/include/boost/proto/transform/detail/preprocessed/call.hpp
+++ b/include/boost/proto/transform/detail/preprocessed/call.hpp
@@ -9,7 +9,7 @@
     
     
     template<typename Fun , typename A0>
-    struct call<Fun(A0, ...)> : transform<call<Fun(A0, ...)> >
+    struct call<Fun(A0 , ...)> : transform<call<Fun(A0 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -29,7 +29,7 @@
     
     
     template<typename Fun , typename A0 , typename A1>
-    struct call<Fun(A0 , A1, ...)> : transform<call<Fun(A0 , A1, ...)> >
+    struct call<Fun(A0 , A1 , ...)> : transform<call<Fun(A0 , A1 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -49,7 +49,7 @@
     
     
     template<typename Fun , typename A0 , typename A1 , typename A2>
-    struct call<Fun(A0 , A1 , A2, ...)> : transform<call<Fun(A0 , A1 , A2, ...)> >
+    struct call<Fun(A0 , A1 , A2 , ...)> : transform<call<Fun(A0 , A1 , A2 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -100,7 +100,7 @@
     
     
     template<typename Fun , typename A0 , typename A1 , typename A2 , typename A3>
-    struct call<Fun(A0 , A1 , A2 , A3, ...)> : transform<call<Fun(A0 , A1 , A2 , A3, ...)> >
+    struct call<Fun(A0 , A1 , A2 , A3 , ...)> : transform<call<Fun(A0 , A1 , A2 , A3 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -151,7 +151,7 @@
     
     
     template<typename Fun , typename A0 , typename A1 , typename A2 , typename A3 , typename A4>
-    struct call<Fun(A0 , A1 , A2 , A3 , A4, ...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4, ...)> >
+    struct call<Fun(A0 , A1 , A2 , A3 , A4 , ...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -202,7 +202,7 @@
     
     
     template<typename Fun , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5>
-    struct call<Fun(A0 , A1 , A2 , A3 , A4 , A5, ...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , A5, ...)> >
+    struct call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , ...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -253,7 +253,7 @@
     
     
     template<typename Fun , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6>
-    struct call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6, ...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6, ...)> >
+    struct call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , ...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -304,7 +304,7 @@
     
     
     template<typename Fun , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7>
-    struct call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7, ...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7, ...)> >
+    struct call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , ...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -355,7 +355,7 @@
     
     
     template<typename Fun , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7 , typename A8>
-    struct call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8, ...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8, ...)> >
+    struct call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , ...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -406,7 +406,7 @@
     
     
     template<typename Fun , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7 , typename A8 , typename A9>
-    struct call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9, ...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9, ...)> >
+    struct call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9 , ...)> : transform<call<Fun(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl

--- a/include/boost/proto/transform/detail/preprocessed/lazy.hpp
+++ b/include/boost/proto/transform/detail/preprocessed/lazy.hpp
@@ -46,8 +46,8 @@
         {};
     };
     template<typename Object , typename A0>
-    struct lazy<Object(A0...)>
-      : transform<lazy<Object(A0...)> >
+    struct lazy<Object(A0, ...)>
+      : transform<lazy<Object(A0, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -84,8 +84,8 @@
         {};
     };
     template<typename Object , typename A0 , typename A1>
-    struct lazy<Object(A0 , A1...)>
-      : transform<lazy<Object(A0 , A1...)> >
+    struct lazy<Object(A0 , A1, ...)>
+      : transform<lazy<Object(A0 , A1, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -122,8 +122,8 @@
         {};
     };
     template<typename Object , typename A0 , typename A1 , typename A2>
-    struct lazy<Object(A0 , A1 , A2...)>
-      : transform<lazy<Object(A0 , A1 , A2...)> >
+    struct lazy<Object(A0 , A1 , A2, ...)>
+      : transform<lazy<Object(A0 , A1 , A2, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -160,8 +160,8 @@
         {};
     };
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3>
-    struct lazy<Object(A0 , A1 , A2 , A3...)>
-      : transform<lazy<Object(A0 , A1 , A2 , A3...)> >
+    struct lazy<Object(A0 , A1 , A2 , A3, ...)>
+      : transform<lazy<Object(A0 , A1 , A2 , A3, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -198,8 +198,8 @@
         {};
     };
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4>
-    struct lazy<Object(A0 , A1 , A2 , A3 , A4...)>
-      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4...)> >
+    struct lazy<Object(A0 , A1 , A2 , A3 , A4, ...)>
+      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -236,8 +236,8 @@
         {};
     };
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5>
-    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , A5...)>
-      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , A5...)> >
+    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , A5, ...)>
+      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , A5, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -274,8 +274,8 @@
         {};
     };
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6>
-    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6...)>
-      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6...)> >
+    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6, ...)>
+      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -312,8 +312,8 @@
         {};
     };
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7>
-    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7...)>
-      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7...)> >
+    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7, ...)>
+      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -350,8 +350,8 @@
         {};
     };
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7 , typename A8>
-    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8...)>
-      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8...)> >
+    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8, ...)>
+      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -388,8 +388,8 @@
         {};
     };
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7 , typename A8 , typename A9>
-    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9...)>
-      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9...)> >
+    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9, ...)>
+      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl

--- a/include/boost/proto/transform/detail/preprocessed/lazy.hpp
+++ b/include/boost/proto/transform/detail/preprocessed/lazy.hpp
@@ -46,8 +46,8 @@
         {};
     };
     template<typename Object , typename A0>
-    struct lazy<Object(A0, ...)>
-      : transform<lazy<Object(A0, ...)> >
+    struct lazy<Object(A0 , ...)>
+      : transform<lazy<Object(A0 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -84,8 +84,8 @@
         {};
     };
     template<typename Object , typename A0 , typename A1>
-    struct lazy<Object(A0 , A1, ...)>
-      : transform<lazy<Object(A0 , A1, ...)> >
+    struct lazy<Object(A0 , A1 , ...)>
+      : transform<lazy<Object(A0 , A1 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -122,8 +122,8 @@
         {};
     };
     template<typename Object , typename A0 , typename A1 , typename A2>
-    struct lazy<Object(A0 , A1 , A2, ...)>
-      : transform<lazy<Object(A0 , A1 , A2, ...)> >
+    struct lazy<Object(A0 , A1 , A2 , ...)>
+      : transform<lazy<Object(A0 , A1 , A2 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -160,8 +160,8 @@
         {};
     };
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3>
-    struct lazy<Object(A0 , A1 , A2 , A3, ...)>
-      : transform<lazy<Object(A0 , A1 , A2 , A3, ...)> >
+    struct lazy<Object(A0 , A1 , A2 , A3 , ...)>
+      : transform<lazy<Object(A0 , A1 , A2 , A3 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -198,8 +198,8 @@
         {};
     };
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4>
-    struct lazy<Object(A0 , A1 , A2 , A3 , A4, ...)>
-      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4, ...)> >
+    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , ...)>
+      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -236,8 +236,8 @@
         {};
     };
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5>
-    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , A5, ...)>
-      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , A5, ...)> >
+    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , ...)>
+      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -274,8 +274,8 @@
         {};
     };
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6>
-    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6, ...)>
-      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6, ...)> >
+    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , ...)>
+      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -312,8 +312,8 @@
         {};
     };
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7>
-    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7, ...)>
-      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7, ...)> >
+    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , ...)>
+      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -350,8 +350,8 @@
         {};
     };
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7 , typename A8>
-    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8, ...)>
-      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8, ...)> >
+    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , ...)>
+      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -388,8 +388,8 @@
         {};
     };
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7 , typename A8 , typename A9>
-    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9, ...)>
-      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9, ...)> >
+    struct lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9 , ...)>
+      : transform<lazy<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl

--- a/include/boost/proto/transform/detail/preprocessed/make.hpp
+++ b/include/boost/proto/transform/detail/preprocessed/make.hpp
@@ -185,8 +185,8 @@
     
     
     template<typename Object , typename A0>
-    struct make<Object(A0, ...)>
-      : transform<make<Object(A0, ...)> >
+    struct make<Object(A0 , ...)>
+      : transform<make<Object(A0 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -309,8 +309,8 @@
     
     
     template<typename Object , typename A0 , typename A1>
-    struct make<Object(A0 , A1, ...)>
-      : transform<make<Object(A0 , A1, ...)> >
+    struct make<Object(A0 , A1 , ...)>
+      : transform<make<Object(A0 , A1 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -433,8 +433,8 @@
     
     
     template<typename Object , typename A0 , typename A1 , typename A2>
-    struct make<Object(A0 , A1 , A2, ...)>
-      : transform<make<Object(A0 , A1 , A2, ...)> >
+    struct make<Object(A0 , A1 , A2 , ...)>
+      : transform<make<Object(A0 , A1 , A2 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -557,8 +557,8 @@
     
     
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3>
-    struct make<Object(A0 , A1 , A2 , A3, ...)>
-      : transform<make<Object(A0 , A1 , A2 , A3, ...)> >
+    struct make<Object(A0 , A1 , A2 , A3 , ...)>
+      : transform<make<Object(A0 , A1 , A2 , A3 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -681,8 +681,8 @@
     
     
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4>
-    struct make<Object(A0 , A1 , A2 , A3 , A4, ...)>
-      : transform<make<Object(A0 , A1 , A2 , A3 , A4, ...)> >
+    struct make<Object(A0 , A1 , A2 , A3 , A4 , ...)>
+      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -805,8 +805,8 @@
     
     
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5>
-    struct make<Object(A0 , A1 , A2 , A3 , A4 , A5, ...)>
-      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , A5, ...)> >
+    struct make<Object(A0 , A1 , A2 , A3 , A4 , A5 , ...)>
+      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , A5 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -929,8 +929,8 @@
     
     
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6>
-    struct make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6, ...)>
-      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6, ...)> >
+    struct make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , ...)>
+      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -1053,8 +1053,8 @@
     
     
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7>
-    struct make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7, ...)>
-      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7, ...)> >
+    struct make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , ...)>
+      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -1177,8 +1177,8 @@
     
     
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7 , typename A8>
-    struct make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8, ...)>
-      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8, ...)> >
+    struct make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , ...)>
+      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -1301,8 +1301,8 @@
     
     
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7 , typename A8 , typename A9>
-    struct make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9, ...)>
-      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9, ...)> >
+    struct make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9 , ...)>
+      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9 , ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl

--- a/include/boost/proto/transform/detail/preprocessed/make.hpp
+++ b/include/boost/proto/transform/detail/preprocessed/make.hpp
@@ -185,8 +185,8 @@
     
     
     template<typename Object , typename A0>
-    struct make<Object(A0...)>
-      : transform<make<Object(A0...)> >
+    struct make<Object(A0, ...)>
+      : transform<make<Object(A0, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -309,8 +309,8 @@
     
     
     template<typename Object , typename A0 , typename A1>
-    struct make<Object(A0 , A1...)>
-      : transform<make<Object(A0 , A1...)> >
+    struct make<Object(A0 , A1, ...)>
+      : transform<make<Object(A0 , A1, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -433,8 +433,8 @@
     
     
     template<typename Object , typename A0 , typename A1 , typename A2>
-    struct make<Object(A0 , A1 , A2...)>
-      : transform<make<Object(A0 , A1 , A2...)> >
+    struct make<Object(A0 , A1 , A2, ...)>
+      : transform<make<Object(A0 , A1 , A2, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -557,8 +557,8 @@
     
     
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3>
-    struct make<Object(A0 , A1 , A2 , A3...)>
-      : transform<make<Object(A0 , A1 , A2 , A3...)> >
+    struct make<Object(A0 , A1 , A2 , A3, ...)>
+      : transform<make<Object(A0 , A1 , A2 , A3, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -681,8 +681,8 @@
     
     
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4>
-    struct make<Object(A0 , A1 , A2 , A3 , A4...)>
-      : transform<make<Object(A0 , A1 , A2 , A3 , A4...)> >
+    struct make<Object(A0 , A1 , A2 , A3 , A4, ...)>
+      : transform<make<Object(A0 , A1 , A2 , A3 , A4, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -805,8 +805,8 @@
     
     
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5>
-    struct make<Object(A0 , A1 , A2 , A3 , A4 , A5...)>
-      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , A5...)> >
+    struct make<Object(A0 , A1 , A2 , A3 , A4 , A5, ...)>
+      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , A5, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -929,8 +929,8 @@
     
     
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6>
-    struct make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6...)>
-      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6...)> >
+    struct make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6, ...)>
+      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -1053,8 +1053,8 @@
     
     
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7>
-    struct make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7...)>
-      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7...)> >
+    struct make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7, ...)>
+      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -1177,8 +1177,8 @@
     
     
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7 , typename A8>
-    struct make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8...)>
-      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8...)> >
+    struct make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8, ...)>
+      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl
@@ -1301,8 +1301,8 @@
     
     
     template<typename Object , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7 , typename A8 , typename A9>
-    struct make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9...)>
-      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9...)> >
+    struct make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9, ...)>
+      : transform<make<Object(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9, ...)> >
     {
         template<typename Expr, typename State, typename Data>
         struct impl

--- a/include/boost/proto/transform/detail/preprocessed/when.hpp
+++ b/include/boost/proto/transform/detail/preprocessed/when.hpp
@@ -92,8 +92,8 @@
     
     
     template<typename Grammar, typename R , typename A0>
-    struct when<Grammar, R(A0, ...)>
-      : detail::when_impl<Grammar, R, R(A0, ...)>
+    struct when<Grammar, R(A0 , ...)>
+      : detail::when_impl<Grammar, R, R(A0 , ...)>
     {};
     
     
@@ -152,8 +152,8 @@
     
     
     template<typename Grammar, typename R , typename A0 , typename A1>
-    struct when<Grammar, R(A0 , A1, ...)>
-      : detail::when_impl<Grammar, R, R(A0 , A1, ...)>
+    struct when<Grammar, R(A0 , A1 , ...)>
+      : detail::when_impl<Grammar, R, R(A0 , A1 , ...)>
     {};
     
     
@@ -212,8 +212,8 @@
     
     
     template<typename Grammar, typename R , typename A0 , typename A1 , typename A2>
-    struct when<Grammar, R(A0 , A1 , A2, ...)>
-      : detail::when_impl<Grammar, R, R(A0 , A1 , A2, ...)>
+    struct when<Grammar, R(A0 , A1 , A2 , ...)>
+      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , ...)>
     {};
     
     
@@ -272,8 +272,8 @@
     
     
     template<typename Grammar, typename R , typename A0 , typename A1 , typename A2 , typename A3>
-    struct when<Grammar, R(A0 , A1 , A2 , A3, ...)>
-      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3, ...)>
+    struct when<Grammar, R(A0 , A1 , A2 , A3 , ...)>
+      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , ...)>
     {};
     
     
@@ -332,8 +332,8 @@
     
     
     template<typename Grammar, typename R , typename A0 , typename A1 , typename A2 , typename A3 , typename A4>
-    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4, ...)>
-      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4, ...)>
+    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , ...)>
+      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , ...)>
     {};
     
     
@@ -392,8 +392,8 @@
     
     
     template<typename Grammar, typename R , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5>
-    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , A5, ...)>
-      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , A5, ...)>
+    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , A5 , ...)>
+      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , A5 , ...)>
     {};
     
     
@@ -452,8 +452,8 @@
     
     
     template<typename Grammar, typename R , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6>
-    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , A5 , A6, ...)>
-      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , A5 , A6, ...)>
+    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , ...)>
+      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , ...)>
     {};
     
     
@@ -512,8 +512,8 @@
     
     
     template<typename Grammar, typename R , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7>
-    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7, ...)>
-      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7, ...)>
+    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , ...)>
+      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , ...)>
     {};
     
     
@@ -572,8 +572,8 @@
     
     
     template<typename Grammar, typename R , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7 , typename A8>
-    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8, ...)>
-      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8, ...)>
+    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , ...)>
+      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , ...)>
     {};
     
     
@@ -632,6 +632,6 @@
     
     
     template<typename Grammar, typename R , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7 , typename A8 , typename A9>
-    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9, ...)>
-      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9, ...)>
+    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9 , ...)>
+      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9 , ...)>
     {};

--- a/include/boost/proto/transform/detail/preprocessed/when.hpp
+++ b/include/boost/proto/transform/detail/preprocessed/when.hpp
@@ -92,8 +92,8 @@
     
     
     template<typename Grammar, typename R , typename A0>
-    struct when<Grammar, R(A0...)>
-      : detail::when_impl<Grammar, R, R(A0...)>
+    struct when<Grammar, R(A0, ...)>
+      : detail::when_impl<Grammar, R, R(A0, ...)>
     {};
     
     
@@ -152,8 +152,8 @@
     
     
     template<typename Grammar, typename R , typename A0 , typename A1>
-    struct when<Grammar, R(A0 , A1...)>
-      : detail::when_impl<Grammar, R, R(A0 , A1...)>
+    struct when<Grammar, R(A0 , A1, ...)>
+      : detail::when_impl<Grammar, R, R(A0 , A1, ...)>
     {};
     
     
@@ -212,8 +212,8 @@
     
     
     template<typename Grammar, typename R , typename A0 , typename A1 , typename A2>
-    struct when<Grammar, R(A0 , A1 , A2...)>
-      : detail::when_impl<Grammar, R, R(A0 , A1 , A2...)>
+    struct when<Grammar, R(A0 , A1 , A2, ...)>
+      : detail::when_impl<Grammar, R, R(A0 , A1 , A2, ...)>
     {};
     
     
@@ -272,8 +272,8 @@
     
     
     template<typename Grammar, typename R , typename A0 , typename A1 , typename A2 , typename A3>
-    struct when<Grammar, R(A0 , A1 , A2 , A3...)>
-      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3...)>
+    struct when<Grammar, R(A0 , A1 , A2 , A3, ...)>
+      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3, ...)>
     {};
     
     
@@ -332,8 +332,8 @@
     
     
     template<typename Grammar, typename R , typename A0 , typename A1 , typename A2 , typename A3 , typename A4>
-    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4...)>
-      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4...)>
+    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4, ...)>
+      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4, ...)>
     {};
     
     
@@ -392,8 +392,8 @@
     
     
     template<typename Grammar, typename R , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5>
-    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , A5...)>
-      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , A5...)>
+    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , A5, ...)>
+      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , A5, ...)>
     {};
     
     
@@ -452,8 +452,8 @@
     
     
     template<typename Grammar, typename R , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6>
-    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , A5 , A6...)>
-      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , A5 , A6...)>
+    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , A5 , A6, ...)>
+      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , A5 , A6, ...)>
     {};
     
     
@@ -512,8 +512,8 @@
     
     
     template<typename Grammar, typename R , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7>
-    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7...)>
-      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7...)>
+    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7, ...)>
+      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7, ...)>
     {};
     
     
@@ -572,8 +572,8 @@
     
     
     template<typename Grammar, typename R , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7 , typename A8>
-    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8...)>
-      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8...)>
+    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8, ...)>
+      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8, ...)>
     {};
     
     
@@ -632,6 +632,6 @@
     
     
     template<typename Grammar, typename R , typename A0 , typename A1 , typename A2 , typename A3 , typename A4 , typename A5 , typename A6 , typename A7 , typename A8 , typename A9>
-    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9...)>
-      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9...)>
+    struct when<Grammar, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9, ...)>
+      : detail::when_impl<Grammar, R, R(A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9, ...)>
     {};


### PR DESCRIPTION
[P0281R0](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0281r0.html) dicourages comma elision in variadic function declarations
The warning is not yet implemented in GCC.